### PR TITLE
Change the way the URL is formed in ttvplaylist_plugin taking the "Host" header into account.

### DIFF
--- a/plugins/ttvplaylist_plugin.py
+++ b/plugins/ttvplaylist_plugin.py
@@ -54,11 +54,8 @@ class Ttvplaylist(AceProxyPlugin):
             if not self.downloadPlaylist():
                 connection.dieWithError()
                 return
-
-        if Ttvplaylist.host:
-            hostport = Ttvplaylist.host + ':' + str(connection.request.getsockname()[1])
-        else:
-            hostport = connection.request.getsockname()[0] + ':' + str(connection.request.getsockname()[1])
+            
+        hostport = connection.headers['Host']
 
         try:
             if connection.splittedpath[2].lower() == 'ts':


### PR DESCRIPTION
Hi,

this makes it possible to use this withing virtual machines, docker containers etc., where port forwarding is used.

This way seems easier and more reliable overall, cause there's no way the address should be different than the Host header.
